### PR TITLE
Bug: Status code (and headers) are not shown for some status codes (e…

### DIFF
--- a/sampleapp/helloworld/api.js
+++ b/sampleapp/helloworld/api.js
@@ -3,6 +3,10 @@ module.exports = function (expressApp, port, basePath) {
     res.sendFile(basePath + req.path)
   })
 
+  expressApp.all('/sampleapp/helloworld/verbs', function (req, res) {
+    res.json({response: 'Hi'})
+  })
+
   expressApp.get('/sampleapp/helloworld/hello', function (req, res) {
     res.json({response: 'Hello World'})
   })
@@ -13,5 +17,9 @@ module.exports = function (expressApp, port, basePath) {
 
   expressApp.all('/sampleapp/helloworld/oldhello*', function (req, res) {
     res.json({response: 'Deprecated operation'})
+  })
+
+  expressApp.get('/sampleapp/helloworld/echo-status', function (req, res) {
+    res.status(req.query.status).json({response: 'status: ' + req.query.status})
   })
 }

--- a/sampleapp/helloworld/helloworld.json
+++ b/sampleapp/helloworld/helloworld.json
@@ -9,7 +9,6 @@
 			"url": "http://www.apache.org/licenses/LICENSE-2.0.html"
 		}
 	},
-	"host": "localhost:3000",
 	"basePath": "/sampleapp/helloworld",
 	"tags": [{
 		"name": "hello",
@@ -23,6 +22,18 @@
 		"http"
 	],
 	"paths": {
+		"/echo-status": {
+			"get":    {
+				"tags": [ "HTTP Status" ],
+				"parameters": [{
+					"name": "status",
+					"in": "query",
+					"description": "HTTP Status Code to return",
+					"required": true,
+					"type": "integer"
+				}]
+			}
+		},
 		"/verbs": {
 			"head":    { "tags": [ "HTTP Verbs" ] },
 			"get":     { "tags": [ "HTTP Verbs" ] },

--- a/sampleapp/helloworld/index.js
+++ b/sampleapp/helloworld/index.js
@@ -1,7 +1,5 @@
 import APIExplorer from './../../src'
 
 APIExplorer
-  .addAPI('helloworld', 'swagger2', `${window.location.protocol}//${window.location.host}/sampleapp/helloworld/helloworld.json`, c => {
-    c.useProxy(true)
-  })
+  .addAPI('helloworld', 'swagger2', `/sampleapp/helloworld/helloworld.json`)
   .start()

--- a/src/components/widgets/TryOutWidgetTab.js
+++ b/src/components/widgets/TryOutWidgetTab.js
@@ -144,14 +144,16 @@ class TryOutWidgetTab extends Component {
 
   requestCallback (request, response) {
     this.props.dispatch(responseReceived(this.props.operation, response, request))
-
     this.setState({requestInProgress: false, response: response, request: request})
 
-    if (response.status >= 200 && response.status < 300) {
-      this.setState({ requestPanelClassName: 'panel panel-http-response panel-success' })
-    } else {
-      this.setState({ requestPanelClassName: 'panel panel-http-response panel-danger' })
+    const statusCategories = {
+      '2': 'panel-success',
+      '3': 'panel-info',
+      '4': 'panel-warning',
+      '5': 'panel-danger'
     }
+    const statusCategory = ('' + response.status).charAt(0)
+    this.setState({ requestPanelClassName: `panel panel-http-response ${statusCategories[statusCategory]}` })
   }
 
   hideResponse (e) {
@@ -171,7 +173,7 @@ class TryOutWidgetTab extends Component {
       width: '100%',
       overflow: 'hidden'
     }
-    const showResponse = !this.state.requestInProgress && this.state.response && this.state.response.data && this.state.response.data !== ''
+    const showResponse = !this.state.requestInProgress && this.state.response
     const showLastResponse = !showResponse && this.props.operationResponse
     const response = !showResponse && this.props.operationResponse ? this.props.operationResponse : this.state.response
     const url = response && response.url


### PR DESCRIPTION
…x: 204, 500)

The bug was having the test "&& this.state.response.data && this.state.response.data !== ''"
This don't work for empty responses!

I've also updated the color of response panels according with the http status code category
 - '2': 'panel-success',
 - '3': 'panel-info',
 - '4': 'panel-warning',
 - '5': 'panel-danger'